### PR TITLE
Add sample live chat server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# im
-即时通讯接口，包含目前主流的容云以及tim，更新配置文件后即可使用
+# Live Chat Server
+
+This project provides a simple Node.js based chat server that can be used as a
+starting point for integrating live streaming chat features. It is designed to
+be extended with third‑party messaging services such as **RongCloud** and
+**Tencent IM**.
+
+## Features
+
+- WebSocket based real-time messaging using `socket.io`.
+- Basic HTTP endpoint to verify the server is running.
+- Configuration file placeholder (`config.json`) for third-party credentials.
+
+## Getting Started
+
+1. Copy `config.example.json` to `config.json` and fill in your credentials for
+   RongCloud or Tencent IM.
+2. Install dependencies (requires internet access):
+
+```bash
+npm install express socket.io
+```
+
+3. Start the server:
+
+```bash
+node server.js
+```
+
+The server listens on port `3000` by default and exposes a WebSocket endpoint
+for clients to exchange messages.
+
+## Notes
+
+Actual API calls to RongCloud or Tencent IM are not implemented in this sample.
+You can add them inside the `chat message` handler in `server.js`.

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,10 @@
+{
+  "rongcloud": {
+    "appKey": "YOUR_APP_KEY",
+    "appSecret": "YOUR_APP_SECRET"
+  },
+  "tencentIM": {
+    "sdkAppId": "YOUR_SDKAPPID",
+    "secretKey": "YOUR_SECRET"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "im",
+  "version": "1.0.0",
+  "description": "即时通讯接口，包含目前主流的容云以及tim，更新配置文件后即可使用",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+const fs = require('fs');
+
+// Load configuration for third-party services if available
+let config = {};
+try {
+  config = JSON.parse(fs.readFileSync('./config.json', 'utf-8'));
+} catch (err) {
+  console.warn('config.json not found, using default config');
+}
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server, {
+  cors: {
+    origin: '*',
+  },
+});
+
+app.get('/', (req, res) => {
+  res.send('Live chat server running');
+});
+
+io.on('connection', (socket) => {
+  console.log('a user connected');
+  socket.on('chat message', (msg) => {
+    // Forward message to 3rd-party services as needed
+    // e.g., RongCloud or Tencent IM API calls (not implemented here)
+    io.emit('chat message', msg);
+  });
+  socket.on('disconnect', () => {
+    console.log('user disconnected');
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create `server.js` with Socket.IO chat server skeleton
- add `config.example.json` with placeholders for RongCloud and Tencent IM credentials
- initialize `package.json`
- rewrite README with setup instructions

## Testing
- `npm install express socket.io` *(fails: 403 Forbidden)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686b62b0f94c832e9cbc40baf15486a3